### PR TITLE
fix:  unable to dynamically scan  and  load PersistenceEntryManagerFactory instances.

### DIFF
--- a/standalone/src/main/java/org/gluu/persist/service/StandalonePersistanceFactoryService.java
+++ b/standalone/src/main/java/org/gluu/persist/service/StandalonePersistanceFactoryService.java
@@ -6,6 +6,7 @@
 
 package org.gluu.persist.service;
 
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import org.gluu.persist.exception.operation.ConfigurationException;
 import org.gluu.persist.model.PersistenceConfiguration;
 import org.gluu.persist.reflect.util.ReflectHelper;
 import org.gluu.persist.service.PersistanceFactoryService;
+import static org.reflections.scanners.Scanners.SubTypes;
 
 /**
  * Factory which creates Persistence Entry Manager
@@ -65,7 +67,8 @@ public class StandalonePersistanceFactoryService extends PersistanceFactoryServi
 		org.reflections.Reflections reflections = new org.reflections.Reflections(new org.reflections.util.ConfigurationBuilder()
 			     .setUrls(org.reflections.util.ClasspathHelper.forPackage("org.gluu.persist"))
 			     .addUrls(org.reflections.util.ClasspathHelper.forPackage("org.gluu.orm"))
-			     .setScanners(new org.reflections.scanners.SubTypesScanner()));
+			     .setScanners(SubTypes));
+		
 		Set<Class<? extends PersistenceEntryManagerFactory>> classes = reflections.getSubTypesOf(PersistenceEntryManagerFactory.class);
 
 		getLog().info("Found '{}' PersistenceEntryManagerFactory", classes.size());


### PR DESCRIPTION
The `StandalonePersistanceFactoryService` is unable to scan and load `PersistenceEntryManagerFactory` instances from 
the classpath. It relies on the `org.reflections` library to do so , which since version 0.10.x introduced a new API and deprecated the `SubTypesScanner` class , in favour of `Scanner.SubTypes`. In version 0.10.1 , that change introduced a bug that made the call to `reflections.getSubTypesOf()` to always return an empty set. The commit in this merge uses the new API to an extend and fixes the issue.